### PR TITLE
Raising project-build-plugin version to 9.4.1 / 10.0.0-SNAPSHOT

### DIFF
--- a/testProjects/latest/Performance/pom.xml
+++ b/testProjects/latest/Performance/pom.xml
@@ -7,7 +7,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>9.4.2-SNAPSHOT</project.build.plugin.version>
+    <project.build.plugin.version>10.0.0-SNAPSHOT</project.build.plugin.version>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Raising project-build-plugin version to 9.4.1 / 10.0.0-SNAPSHOT